### PR TITLE
Add padding-left to avoid overflow left side

### DIFF
--- a/static/css/main.less
+++ b/static/css/main.less
@@ -37,6 +37,7 @@ code {
 
 #main {
     margin-top: 50px;
+    padding-left: 20px;
 }
 
 #APIDocs {


### PR DESCRIPTION
![](http://go-gyazo.appspot.com/b03ed5a8ba8be35b.png)

When narrowing window size enough to be shown scroll-bar, and pick the scroll-bar left, page will overflow left side.
