### PR TITLE
Listing only current failures

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -38,7 +38,6 @@ requires 'Getopt::Long';
 requires 'Plack::Loader';
 requires 'Pod::Usage';
 requires 'Starlet';
-requires 'SQL::Interp';
 
 on 'develop' => sub {
     requires 'Locale::Maketext::Extract::Plugin::Xslate', 'v0.0.2';

--- a/lib/Ukigumo/Server/Web/Dispatcher.pm
+++ b/lib/Ukigumo/Server/Web/Dispatcher.pm
@@ -104,8 +104,8 @@ get '/all_failure' => sub {
             reports   => $reports,
             pager     => $pager,
             now       => time(),
-         }
-     );
+        }
+    );
 };
 
 get '/project/{project}' => sub {

--- a/share/tmpl/include/layout.tx
+++ b/share/tmpl/include/layout.tx
@@ -31,7 +31,7 @@
                             <a href="<: uri_for('/failure') :>">Failure</a>
                         </li>
                         <li>
-                            <a href="<: uri_for('/all_failure') :>">AllFailure</a>
+                            <a href="<: uri_for('/all_failure') :>">All Failure</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
Hi.

I'd like to add this feature for our use case.
I think 'failure' page should list only current failed branch (NOT all failed revisions).
How do you think?

This implementation is just a prototype.
if code quality/style is not enough for merge, I can fix it.
