### PR TITLE
Delete old reports for keeping DB file size constant.

### DIFF
--- a/lib/Ukigumo/Server/Command/Report.pm
+++ b/lib/Ukigumo/Server/Command/Report.pm
@@ -196,6 +196,28 @@ sub insert {
         branch_id => $branch_id,
     });
 
+    if (defined c->config->{max_report_size_by_branch}) {
+        my $last = [ c->db->search_named(q{ SELECT report_id FROM report WHERE branch_id = :branch_id ORDER BY report_id DESC LIMIT :limit }, {
+            limit     => c->config->{max_report_size_by_branch},
+            branch_id => $branch_id,
+        }) ]->[-1];
+
+        c->db->delete('report', {
+            report_id => { '<' => $last->report_id },
+            branch_id => $branch_id,
+        });
+    }
+
+    if (defined c->config->{max_report_size}) {
+        my $last = [ c->db->search_named(q{ SELECT report_id FROM report ORDER BY report_id DESC LIMIT :limit }, {
+            limit     => c->config->{max_report_size},
+        }) ]->[-1];
+
+        c->db->delete('report', {
+            report_id => { '<' => $last->report_id },
+        });
+    }
+
     $txn->commit;
 
     return $report_id;

--- a/share/config/deployment.pl
+++ b/share/config/deployment.pl
@@ -7,4 +7,7 @@
             sqlite_unicode => 1,
         }
     ],
+
+    max_report_size_by_branch => 1000,
+    max_report_size => 5000,
 };

--- a/t/Command/Report.t
+++ b/t/Command/Report.t
@@ -1,0 +1,55 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use t::Util;
+
+use Ukigumo::Server;
+use Ukigumo::Server::Command::Report;
+
+my $app = test_ukigumo;
+my $c = Ukigumo::Server->bootstrap;
+
+subtest 'remove old report' => sub {
+    $c->dbh->selectall_arrayref(q{DELETE FROM report});
+
+    $c->config->{max_report_size_by_branch} = 3;
+    $c->config->{max_report_size} = 5;
+
+    my $reports_1 = [];
+    for my $rev (1..4) {
+        push @$reports_1, Ukigumo::Server::Command::Report->insert(
+            project => 'MyProj1',
+            branch  => 'master',
+            status  => '1',
+            revision => $rev,
+        );
+    }
+
+    ok !Ukigumo::Server::Command::Report->find(report_id => $reports_1->[0]), 'deleted by max_report_size_by_branch';
+    ok +Ukigumo::Server::Command::Report->find(report_id => $reports_1->[1]);
+    ok +Ukigumo::Server::Command::Report->find(report_id => $reports_1->[2]);
+    ok +Ukigumo::Server::Command::Report->find(report_id => $reports_1->[3]);
+
+    my $reports_2 = [];
+    for my $rev (1..4) {
+        push @$reports_2, Ukigumo::Server::Command::Report->insert(
+            project => 'MyProj2',
+            branch  => 'master',
+            status  => '1',
+            revision => $rev,
+        );
+    }
+
+    ok !Ukigumo::Server::Command::Report->find(report_id => $reports_2->[0]), 'deleted by max_report_size_by_branch';
+    ok +Ukigumo::Server::Command::Report->find(report_id => $reports_2->[1]);
+    ok +Ukigumo::Server::Command::Report->find(report_id => $reports_2->[2]);
+    ok +Ukigumo::Server::Command::Report->find(report_id => $reports_2->[3]);
+
+    ok !Ukigumo::Server::Command::Report->find(report_id => $reports_1->[1]), 'deleted by max_report_size';
+    ok +Ukigumo::Server::Command::Report->find(report_id => $reports_1->[2]);
+    ok +Ukigumo::Server::Command::Report->find(report_id => $reports_1->[3]);
+};
+
+done_testing;


### PR DESCRIPTION
Implemented as two configuration options like below:
1. max_report_size_by_branch: Limit count for each branch.
2. max_report_size: Whole limit count for report rows.
