### PR TITLE
Fix 'return-or-die' statements.

### DIFF
--- a/lib/Ukigumo/Server/API.pm
+++ b/lib/Ukigumo/Server/API.pm
@@ -9,7 +9,7 @@ use Ukigumo::Server::API::Dispatcher;
 
 sub dispatch {
     my $c = shift;
-    return Ukigumo::Server::API::Dispatcher->dispatch($c) or die "response is not generated";
+    return Ukigumo::Server::API::Dispatcher->dispatch($c) || die "response is not generated";
 }
 
 __PACKAGE__->load_plugins( 'Web::JSON' );

--- a/lib/Ukigumo/Server/Web.pm
+++ b/lib/Ukigumo/Server/Web.pm
@@ -11,8 +11,7 @@ use Ukigumo::Constants;
 use Ukigumo::Server::Web::Dispatcher;
 sub dispatch {
     my $c = shift;
-    return Ukigumo::Server::Web::Dispatcher->dispatch($c)
-      or die "response is not generated";
+    return Ukigumo::Server::Web::Dispatcher->dispatch($c) || die "response is not generated";
 }
 
 # setup view class


### PR DESCRIPTION
Statements like this:

    return do_something() or die "something is wrong";

... are almost certainly mistakes. Since `or` has lower precedence
than `return`, it is equivalent to:

   ( return do_something() ) or die "something_is wrong";

Since `return` takes the value to caller, the `or` operator and the
order side of it never executes.